### PR TITLE
Enable multiple answers to a question

### DIFF
--- a/apps/artemis/lib/artemis/schemas/event_answer.ex
+++ b/apps/artemis/lib/artemis/schemas/event_answer.ex
@@ -8,6 +8,8 @@ defmodule Artemis.EventAnswer do
     field :type, :string
     field :value, :string
 
+    field :delete, :boolean, default: false, virtual: true
+
     belongs_to :event_question, Artemis.EventQuestion, on_replace: :delete
     belongs_to :project, Artemis.Project, on_replace: :delete
     belongs_to :user, Artemis.User, on_replace: :delete

--- a/apps/artemis_web/assets/css/main.scss
+++ b/apps/artemis_web/assets/css/main.scss
@@ -1104,13 +1104,14 @@ ul.event-answers {
     .event-answer {
 
       &.marked-for-deletion {
-        visibility: hidden;
-        height: 1px;
-        left: 0px;
-        overflow: none;
-        position: absolute;
-        top: 0px;
-        width: 1px;
+        border: 0 !important;
+        clip: rect(0 0 0 0) !important;
+        height: 1px !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        padding: 0 !important;
+        position: absolute !important;
+        width: 1px !important;
       }
 
       .project-field {

--- a/apps/artemis_web/assets/css/main.scss
+++ b/apps/artemis_web/assets/css/main.scss
@@ -1034,7 +1034,7 @@ ul.event-instances {
 .event-question {
   margin: 1rem 0;
 
-  h4 .required {
+  h4 .subheading {
     color: rgba(0, 0, 0, 0.4);
     display: inline-block;
     margin-left: 0.25rem;

--- a/apps/artemis_web/assets/css/main.scss
+++ b/apps/artemis_web/assets/css/main.scss
@@ -1083,25 +1083,63 @@ ul.event-answers {
 #event-instance-form {
 
   .event-question {
-    margin: 0 0 1rem 0;
+    position: relative;
+    margin: 0rem 0 2rem 0;
 
     h4 {
       margin: 0 0 0.5rem 0;
     }
-  }
 
-  .project-field {
-    font-size: 13px;
-    width: 180px;
-  }
-
-  .answer-field {
-    flex-grow: 1;
-
-    textarea {
-      line-height: 18px;
+    .add-event-answer {
+      box-shadow: none;
+      color: $light_blue !important;
       font-size: 13px;
-      height: 38px;
+      padding: 0;
+
+      &:hover {
+        color: $blue_muted !important;
+      }
+    }
+
+    .event-answer {
+
+      &.marked-for-deletion {
+        visibility: hidden;
+        height: 1px;
+        left: 0px;
+        overflow: none;
+        position: absolute;
+        top: 0px;
+        width: 1px;
+      }
+
+      .project-field {
+        font-size: 13px;
+        width: 180px;
+      }
+
+      .answer-field {
+        flex-grow: 1;
+
+        textarea {
+          line-height: 18px;
+          font-size: 13px;
+          height: 38px;
+        }
+      }
+
+      .delete-field {
+
+        button {
+          background: #fff;
+          height: 38px;
+          width: 38px;
+
+          &:hover {
+            color: $status_red;
+          }
+        }
+      }
     }
   }
 }

--- a/apps/artemis_web/assets/js/live_view.js
+++ b/apps/artemis_web/assets/js/live_view.js
@@ -1,6 +1,7 @@
 import {Socket} from "phoenix"
 import LiveSocket from "phoenix_live_view"
 import AmChartHelpers from "./am_charts"
+import Select2Helpers from "./select2"
 
 // LiveView Browser Polyfills
 
@@ -16,6 +17,7 @@ import "formdata-polyfill"
 const LiveViewHooks = {}
 
 LiveViewHooks.AmCharts = AmChartHelpers.live_view_hooks
+LiveViewHooks.Select2 = Select2Helpers.live_view_hooks
 
 // LiveView Initialization
 

--- a/apps/artemis_web/assets/js/select2.js
+++ b/apps/artemis_web/assets/js/select2.js
@@ -3,14 +3,8 @@ const Select2Helpers = {}
 // Helpers - Phoenix LiveView
 
 Select2Helpers.live_view_hooks = {
-  mounted() {
-    console.log("mounted!", global.vendor_initializers)
-    global.vendor_initializers.select2()
-  },
-  updated() {
-    console.log("updated!", global.vendor_initializers)
-    global.vendor_initializers.select2()
-  }
+  mounted() { global.vendor_initializers.select2() },
+  updated() { global.vendor_initializers.select2() }
 }
 
 // Exports

--- a/apps/artemis_web/assets/js/select2.js
+++ b/apps/artemis_web/assets/js/select2.js
@@ -1,0 +1,18 @@
+const Select2Helpers = {}
+
+// Helpers - Phoenix LiveView
+
+Select2Helpers.live_view_hooks = {
+  mounted() {
+    console.log("mounted!", global.vendor_initializers)
+    global.vendor_initializers.select2()
+  },
+  updated() {
+    console.log("updated!", global.vendor_initializers)
+    global.vendor_initializers.select2()
+  }
+}
+
+// Exports
+
+export default Select2Helpers

--- a/apps/artemis_web/assets/vendor/99-initializers.js
+++ b/apps/artemis_web/assets/vendor/99-initializers.js
@@ -132,19 +132,20 @@ function initializeSelect2() {
     var item = $(this)
     var classes = item.attr('class').split(' ')
     var options = {}
+    var initialized = classes.includes('select2-hidden-accessible')
 
-    // Options
-    var hasClearable = classes.includes('clearable')
-    var hasCreate = classes.includes('creatable') || classes.includes('tags')
-    var hasSearch = classes.includes('search')
+    if (!initialized) {
+      var hasClearable = classes.includes('clearable')
+      var hasCreate = classes.includes('creatable') || classes.includes('tags')
+      var hasSearch = classes.includes('search')
 
-    options.allowClear = hasClearable
-    options.minimumResultsForSearch = hasSearch ? 0 : Infinity
-    options.tags = hasCreate
-    options.placeholder = item.attr('placeholder') || ''
+      options.allowClear = hasClearable
+      options.minimumResultsForSearch = hasSearch ? 0 : Infinity
+      options.tags = hasCreate
+      options.placeholder = item.attr('placeholder') || ''
 
-    // Initialize
-    item.select2(options)
+      item.select2(options)
+    }
   })
 }
 

--- a/apps/artemis_web/assets/vendor/99-initializers.js
+++ b/apps/artemis_web/assets/vendor/99-initializers.js
@@ -376,3 +376,7 @@ $(document).ready(function() {
   initializeSelectTableRow()
   initializeWikiSidenav()
 })
+
+window.vendor_initializers = {
+  select2: initializeSelect2
+}

--- a/apps/artemis_web/lib/artemis_web/controllers/event_instance_controller.ex
+++ b/apps/artemis_web/lib/artemis_web/controllers/event_instance_controller.ex
@@ -299,10 +299,15 @@ defmodule ArtemisWeb.EventInstanceController do
   end
 
   defp record_event_answer(params, user) do
+    id = Map.get(params, "id")
+    id? = !is_nil(id)
+    delete? = Map.get(params, "delete") == "true"
+
     action =
-      case Map.get(params, "id") do
-        nil -> fn params, user -> Artemis.CreateEventAnswer.call(params, user) end
-        id -> fn params, user -> Artemis.UpdateEventAnswer.call(id, params, user) end
+      cond do
+        id? && delete? -> fn _params, user -> Artemis.DeleteEventAnswer.call(id, user) end
+        id? -> fn params, user -> Artemis.UpdateEventAnswer.call(id, params, user) end
+        true -> fn params, user -> Artemis.CreateEventAnswer.call(params, user) end
       end
 
     case action.(params, user) do

--- a/apps/artemis_web/lib/artemis_web/controllers/event_instance_controller.ex
+++ b/apps/artemis_web/lib/artemis_web/controllers/event_instance_controller.ex
@@ -61,6 +61,7 @@ defmodule ArtemisWeb.EventInstanceController do
       event_answers = add_default_event_answers(date, event_questions, existing_event_answers, user)
 
       assigns = [
+        csrf_token: Phoenix.Controller.get_csrf_token(),
         date: date,
         event_answers: event_answers,
         event_questions: event_questions,
@@ -90,6 +91,7 @@ defmodule ArtemisWeb.EventInstanceController do
           event_answers = add_default_event_answers(date, event_questions, existing_event_answers, user)
 
           assigns = [
+            csrf_token: Phoenix.Controller.get_csrf_token(),
             date: date,
             event_answers: event_answers,
             event_questions: event_questions,

--- a/apps/artemis_web/lib/artemis_web/controllers/event_instance_controller.ex
+++ b/apps/artemis_web/lib/artemis_web/controllers/event_instance_controller.ex
@@ -55,10 +55,8 @@ defmodule ArtemisWeb.EventInstanceController do
       user = current_user(conn)
       event_template = get_event_template!(event_template_id, user)
       event_questions = get_event_questions(event_template_id, user)
+      event_answers = get_event_answers_for_update(event_template_id, date, user)
       projects = get_projects(event_template.team_id, user)
-
-      existing_event_answers = get_event_answers_for_update(event_template_id, date, user)
-      event_answers = add_default_event_answers(date, event_questions, existing_event_answers, user)
 
       assigns = [
         csrf_token: Phoenix.Controller.get_csrf_token(),
@@ -86,9 +84,8 @@ defmodule ArtemisWeb.EventInstanceController do
           |> put_flash(:info, "Event Instance updated successfully.")
           |> redirect(to: Routes.event_instance_path(conn, :show, event_template_id, date))
 
-        {:error, existing_event_answers} ->
+        {:error, event_answers} ->
           projects = get_projects(event_template.team_id, user)
-          event_answers = add_default_event_answers(date, event_questions, existing_event_answers, user)
 
           assigns = [
             csrf_token: Phoenix.Controller.get_csrf_token(),
@@ -186,32 +183,6 @@ defmodule ArtemisWeb.EventInstanceController do
     params
     |> ListEventAnswers.call(user)
     |> Enum.map(&EventAnswer.changeset(&1))
-  end
-
-  defp add_default_event_answers(date, event_questions, event_answers, user) do
-    Enum.reduce(event_questions, event_answers, fn event_question, acc ->
-      filtered =
-        Enum.filter(event_answers, fn event_answer ->
-          current = Ecto.Changeset.get_field(event_answer, :event_question_id)
-          match = event_question.id
-
-          current == match
-        end)
-
-      empty_event_answer = %Artemis.EventAnswer{
-        date: date,
-        event_question_id: event_question.id,
-        type: event_question.type,
-        user_id: user.id
-      }
-
-      empty_event_answer_changeset = Artemis.EventAnswer.changeset(empty_event_answer)
-
-      case length(filtered) do
-        0 -> [empty_event_answer_changeset | acc]
-        _ -> acc
-      end
-    end)
   end
 
   defp get_projects(team_id, user) do

--- a/apps/artemis_web/lib/artemis_web/live/event_instance_form_live.ex
+++ b/apps/artemis_web/lib/artemis_web/live/event_instance_form_live.ex
@@ -5,15 +5,23 @@ defmodule ArtemisWeb.EventInstanceFormLive do
 
   @impl true
   def mount(session, socket) do
+    event_answers_with_defaults = add_default_event_answers(
+      session.date,
+      session.event_questions,
+      session.event_answers,
+      session.user
+    )
+
     assigns =
       socket
       |> assign(:action, session.action)
       |> assign(:csrf_token, session.csrf_token)
       |> assign(:date, session.date)
-      |> assign(:event_answers, session.event_answers)
+      |> assign(:event_answers, event_answers_with_defaults)
       |> assign(:event_questions, session.event_questions)
       |> assign(:event_template, session.event_template)
       |> assign(:projects, session.projects)
+      |> assign(:user, session.user)
 
     {:ok, assigns}
   end
@@ -26,9 +34,57 @@ defmodule ArtemisWeb.EventInstanceFormLive do
   # GenServer Callbacks
 
   @impl true
-  def handle_info(:hello, socket) do
-    assigns = assign(socket, :hello, [])
+  def handle_event("create", values, socket) do
+    date = Map.get(values, "date")
+    event_question_id = String.to_integer(Map.get(values, "event_question_id"))
+    event_question_type = Map.get(values, "event_question_type")
+    user_id = String.to_integer(Map.get(values, "user_id"))
 
-    {:noreply, assigns}
+    new_event_answer = create_event_answer_changeset(date, event_question_id, event_question_type, user_id)
+    updated_event_answers = socket.assigns.event_answers ++ [new_event_answer]
+
+    socket = assign(socket, :event_answers, updated_event_answers)
+
+    {:noreply, socket}
+  end
+
+  # Helpers
+
+  defp add_default_event_answers(date, event_questions, event_answers, user) do
+    Enum.reduce(event_questions, event_answers, fn event_question, acc ->
+      filtered =
+        Enum.filter(event_answers, fn event_answer ->
+          current = Ecto.Changeset.get_field(event_answer, :event_question_id)
+          match = event_question.id
+
+          current == match
+        end)
+
+      case length(filtered) do
+        0 ->
+          default_answer_changeset = create_event_answer_changeset(
+            date,
+            event_question.id,
+            event_question.type,
+            user.id
+          )
+
+          [default_answer_changeset | acc]
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp create_event_answer_changeset(date, event_question_id, event_question_type, user_id) do
+    empty_event_answer = %Artemis.EventAnswer{
+      date: date,
+      event_question_id: event_question_id,
+      type: event_question_type,
+      user_id: user_id
+    }
+
+    Artemis.EventAnswer.changeset(empty_event_answer)
   end
 end

--- a/apps/artemis_web/lib/artemis_web/live/event_instance_form_live.ex
+++ b/apps/artemis_web/lib/artemis_web/live/event_instance_form_live.ex
@@ -1,0 +1,34 @@
+defmodule ArtemisWeb.EventInstanceFormLive do
+  use ArtemisWeb.LiveView
+
+  # LiveView Callbacks
+
+  @impl true
+  def mount(session, socket) do
+    assigns =
+      socket
+      |> assign(:action, session.action)
+      |> assign(:csrf_token, session.csrf_token)
+      |> assign(:date, session.date)
+      |> assign(:event_answers, session.event_answers)
+      |> assign(:event_questions, session.event_questions)
+      |> assign(:event_template, session.event_template)
+      |> assign(:projects, session.projects)
+
+    {:ok, assigns}
+  end
+
+  @impl true
+  def render(assigns) do
+    Phoenix.View.render(ArtemisWeb.EventInstanceView, "form.html", assigns)
+  end
+
+  # GenServer Callbacks
+
+  @impl true
+  def handle_info(:hello, socket) do
+    assigns = assign(socket, :hello, [])
+
+    {:noreply, assigns}
+  end
+end

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/edit.html.eex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/edit.html.eex
@@ -25,9 +25,9 @@
       form_assigns =
         assigns
         |> Map.put(:action, Routes.event_instance_path(@conn, :update, @event_template, @date))
-        |> Map.put(:event_template, @event_template)
+        |> Map.put(:user, current_user(@conn))
 
-      render "form.html", form_assigns
+      render_event_instance_form @conn, form_assigns
     %>
   </section>
 </div>

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.eex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.eex
@@ -3,39 +3,23 @@
     <div class="event-question">
       <h4>
         <%= event_question.title %>
-        <span class="required">
-          <%= if event_question.required, do: "Required", else: "Optional" %>
+        <span class="subheading">
+          <%= unless event_question.required, do: "Optional" %>
         </span>
       </h4>
 
       <%= raw event_question.description_html %>
 
       <%
-        existing_event_answers =
-          Enum.filter(@event_answers, fn event_answer ->
-            get_changeset_value(event_answer, :event_question_id) == event_question.id
-          end)
-
-        empty_event_answer = %Artemis.EventAnswer{
-          date: @date,
-          event_question_id: event_question.id,
-          type: event_question.type,
-          user_id: current_user(@conn).id
-        }
-
-        empty_event_answer_changeset = Artemis.EventAnswer.changeset(empty_event_answer)
-
-        event_answers =
-          case length(existing_event_answers) do
-            0 -> [empty_event_answer_changeset]
-            _ -> existing_event_answers
-          end
-
-        event_answers = Enum.with_index(event_answers)
+        event_answers_for_event_question =
+          @event_answers
+          |> Enum.filter(&(get_changeset_value(&1, :event_question_id) == event_question.id))
+          |> Enum.with_index()
       %>
 
-      <%= if length(event_answers) > 0 do %>
-        <%= Enum.map event_answers, fn {event_answer, index} -> %>
+      <%= if length(event_answers_for_event_question) > 0 do %>
+
+        <%= Enum.map event_answers_for_event_question, fn {event_answer, index} -> %>
 
           <%= if !event_answer.valid? && event_answer.action do %>
             <%= render_notification :error, body: "Error: Invalid Event Answer", header?: false, icon?: false %>

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.eex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.eex
@@ -29,6 +29,10 @@
             <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][id]" value="<%= get_changeset_value(event_answer, :id) %>">
           <% end %>
 
+          <%= if get_changeset_value(event_answer, :delete) do %>
+            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][delete]" value="true">
+          <% end %>
+
           <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][date]" value="<%= @date %>">
           <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][event_question_id]" value="<%= event_question.id %>">
           <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][type]" value="<%= get_changeset_value(event_answer, :type) %>">

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
@@ -1,4 +1,4 @@
-<form accept-charset="UTF-8" action="<%= @action %>" class="ui form" id="event-instance-form" method="post">
+<form accept-charset="UTF-8" action="<%= @action %>" class="ui form" id="event-instance-form" method="post" phx-hook="Select2">
   <input name="_utf8" type="hidden" value="✓">
   <input name="_method" type="hidden" value="put">
   <input name="_csrf_token" type="hidden" value="<%= @csrf_token %>">
@@ -52,7 +52,7 @@
             <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][user_id]" value="<%= get_changeset_value(event_answer, :user_id) %>">
 
             <div class="inline-fields">
-              <div class="field project-field">
+              <div class="field project-field" phx-update="ignore">
                 <select
                   class="enhanced clearable"
                   name="event_instance[<%= event_question.id %>][<%= index %>][project_id]"
@@ -61,10 +61,10 @@
                 >
                   <option value=""></option>
                   <%=
-                    current_value = get_changeset_value(event_answer, :project_id)
-                    values = Enum.map(@projects, &[key: &1.title, value: &1.id])
+                    current_project_id = get_changeset_value(event_answer, :project_id)
+                    project_id_values = Enum.map(@projects, &[key: &1.title, value: &1.id])
 
-                    deprecated_options_for_select(values, current_value)
+                    deprecated_options_for_select(project_id_values, current_project_id)
                   %>
                 </select>
               </div>

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
@@ -29,52 +29,65 @@
 
         <%= Enum.map event_answers_for_event_question, fn {event_answer, index} -> %>
 
-          <%= if !event_answer.valid? && event_answer.action do %>
-            <%= render_notification :error, body: "Error: Invalid Event Answer", header?: false, icon?: false %>
-          <% end %>
+          <div class="event-answer">
 
-          <%= if get_changeset_value(event_answer, :id) do %>
-            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][id]" value="<%= get_changeset_value(event_answer, :id) %>">
-          <% end %>
+            <%= if !event_answer.valid? && event_answer.action do %>
+              <%= render_notification :error, body: "Error: Invalid Event Answer", header?: false, icon?: false %>
+            <% end %>
 
-          <%= if get_changeset_value(event_answer, :delete) do %>
-            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][delete]" value="true">
-          <% end %>
+            <%= if get_changeset_value(event_answer, :id) do %>
+              <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][id]" value="<%= get_changeset_value(event_answer, :id) %>">
+            <% end %>
 
-          <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][date]" value="<%= @date %>">
-          <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][event_question_id]" value="<%= event_question.id %>">
-          <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][type]" value="<%= get_changeset_value(event_answer, :type) %>">
-          <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][user_id]" value="<%= get_changeset_value(event_answer, :user_id) %>">
+            <%= if get_changeset_value(event_answer, :delete) do %>
+              <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][delete]" value="true">
+            <% end %>
 
-          <div class="inline-fields">
-            <div class="field project-field">
-              <select
-                class="enhanced clearable"
-                name="event_instance[<%= event_question.id %>][<%= index %>][project_id]"
-                type="text"
-                placeholder="Project"
-              >
-                <option value=""></option>
-                <%=
-                  current_value = get_changeset_value(event_answer, :project_id)
-                  values = Enum.map(@projects, &[key: &1.title, value: &1.id])
+            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][date]" value="<%= @date %>">
+            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][event_question_id]" value="<%= event_question.id %>">
+            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][type]" value="<%= get_changeset_value(event_answer, :type) %>">
+            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][user_id]" value="<%= get_changeset_value(event_answer, :user_id) %>">
 
-                  deprecated_options_for_select(values, current_value)
-                %>
-              </select>
-            </div>
+            <div class="inline-fields">
+              <div class="field project-field">
+                <select
+                  class="enhanced clearable"
+                  name="event_instance[<%= event_question.id %>][<%= index %>][project_id]"
+                  type="text"
+                  placeholder="Project"
+                >
+                  <option value=""></option>
+                  <%=
+                    current_value = get_changeset_value(event_answer, :project_id)
+                    values = Enum.map(@projects, &[key: &1.title, value: &1.id])
 
-            <div class="field answer-field">
-              <textarea
-                name="event_instance[<%= event_question.id %>][<%= index %>][value]"
-                rows="1"
-                placeholder="Answer"
-              ><%= get_changeset_value(event_answer, :value) %></textarea>
+                    deprecated_options_for_select(values, current_value)
+                  %>
+                </select>
+              </div>
+
+              <div class="field answer-field">
+                <textarea
+                  name="event_instance[<%= event_question.id %>][<%= index %>][value]"
+                  rows="1"
+                  placeholder="Answer"
+                ><%= get_changeset_value(event_answer, :value) %></textarea>
+              </div>
             </div>
           </div>
 
         <% end %>
       <% end %>
+
+      <button
+        type="button"
+        class="ui button basic"
+        phx-click="create"
+        phx-value-date="<%= @date %>"
+        phx-value-event_question_id="<%= event_question.id %>"
+        phx-value-event_question_type="<%= event_question.type %>"
+        phx-value-user_id="<%= @user.id %>"
+      >+ Answer</button>
     </div>
   <% end %>
 

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
@@ -1,4 +1,12 @@
-<%= form_for @conn, @action, [method: :put, class: "ui form", id: "event-instance-form"], fn f -> %>
+<form accept-charset="UTF-8" action="<%= @action %>" class="ui form" id="event-instance-form" method="post">
+  <input name="_utf8" type="hidden" value="✓">
+  <input name="_method" type="hidden" value="put">
+  <input name="_csrf_token" type="hidden" value="<%= @csrf_token %>">
+
+  <input name="id" type="hidden" value="<%= @date %>">
+  <input name="date" type="hidden" value="<%= @date %>">
+  <input name="event_template_id" type="hidden" value="<%= @event_template.id %>">
+
   <%= Enum.map @event_questions, fn event_question -> %>
     <div class="event-question">
       <h4>
@@ -70,13 +78,7 @@
     </div>
   <% end %>
 
-  <%= hidden_input f, :id, value: @date %>
-
-  <%= hidden_input f, :date, value: @date %>
-
-  <%= hidden_input f, :event_template_id, value: @event_template.id %>
-
   <div>
     <%= submit "Save", class: "ui button primary" %>
   </div>
-<% end %>
+</form>

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
@@ -29,7 +29,9 @@
 
         <%= Enum.map event_answers_for_event_question, fn {event_answer, index} -> %>
 
-          <div class="event-answer">
+          <% deleted_class = if get_changeset_value(event_answer, :delete), do: "marked-for-deletion" %>
+
+          <div class="event-answer <%= deleted_class %>">
 
             <%= if !event_answer.valid? && event_answer.action do %>
               <%= render_notification :error, body: "Error: Invalid Event Answer", header?: false, icon?: false %>
@@ -43,6 +45,7 @@
               <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][delete]" value="true">
             <% end %>
 
+            <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][changeset_id]" value="<%= get_changeset_value(event_answer, :changeset_id) %>">
             <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][date]" value="<%= @date %>">
             <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][event_question_id]" value="<%= event_question.id %>">
             <input type="hidden" name="event_instance[<%= event_question.id %>][<%= index %>][type]" value="<%= get_changeset_value(event_answer, :type) %>">
@@ -73,6 +76,17 @@
                   placeholder="Answer"
                 ><%= get_changeset_value(event_answer, :value) %></textarea>
               </div>
+
+              <div class="field delete-field">
+                <button
+                  type="button"
+                  class="ui icon button"
+                  phx-click="delete"
+                  phx-value-changeset_id="<%= get_changeset_value(event_answer, :changeset_id) %>"
+                >
+                  <i class="trash icon"></i>
+                </button>
+              </div>
             </div>
           </div>
 
@@ -80,14 +94,16 @@
       <% end %>
 
       <button
-        type="button"
-        class="ui button basic"
+        class="ui button basic add-event-answer"
         phx-click="create"
         phx-value-date="<%= @date %>"
         phx-value-event_question_id="<%= event_question.id %>"
         phx-value-event_question_type="<%= event_question.type %>"
         phx-value-user_id="<%= @user.id %>"
-      >+ Answer</button>
+        type="button"
+      >
+        + Add Answer
+      </button>
     </div>
   <% end %>
 

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/form.html.leex
@@ -77,33 +77,37 @@
                 ><%= get_changeset_value(event_answer, :value) %></textarea>
               </div>
 
-              <div class="field delete-field">
-                <button
-                  type="button"
-                  class="ui icon button"
-                  phx-click="delete"
-                  phx-value-changeset_id="<%= get_changeset_value(event_answer, :changeset_id) %>"
-                >
-                  <i class="trash icon"></i>
-                </button>
-              </div>
+              <%= if event_question.multiple do %>
+                <div class="field delete-field">
+                  <button
+                    type="button"
+                    class="ui icon button"
+                    phx-click="delete"
+                    phx-value-changeset_id="<%= get_changeset_value(event_answer, :changeset_id) %>"
+                  >
+                    <i class="trash icon"></i>
+                  </button>
+                </div>
+              <% end %>
             </div>
           </div>
 
         <% end %>
       <% end %>
 
-      <button
-        class="ui button basic add-event-answer"
-        phx-click="create"
-        phx-value-date="<%= @date %>"
-        phx-value-event_question_id="<%= event_question.id %>"
-        phx-value-event_question_type="<%= event_question.type %>"
-        phx-value-user_id="<%= @user.id %>"
-        type="button"
-      >
-        + Add Answer
-      </button>
+      <%= if event_question.multiple do %>
+        <button
+          class="ui button basic add-event-answer"
+          phx-click="create"
+          phx-value-date="<%= @date %>"
+          phx-value-event_question_id="<%= event_question.id %>"
+          phx-value-event_question_type="<%= event_question.type %>"
+          phx-value-user_id="<%= @user.id %>"
+          type="button"
+        >
+          + Add Answer
+        </button>
+      <% end %>
     </div>
   <% end %>
 

--- a/apps/artemis_web/lib/artemis_web/templates/event_instance/show/_summary_by_project.slack.eex
+++ b/apps/artemis_web/lib/artemis_web/templates/event_instance/show/_summary_by_project.slack.eex
@@ -1,8 +1,14 @@
 <%
   entries =
     @event_questions
-    |> Enum.map(fn {event_question, event_answers} ->
+    |> Map.keys()
+    |> Enum.sort_by(&{
+      &1.order,
+      &1.inserted_at
+    })
+    |> Enum.map(fn event_question ->
       label = "\\n*#{event_question.title}*\\n"
+      event_answers = Map.get(@event_questions, event_question)
 
       values =
         event_answers

--- a/apps/artemis_web/lib/artemis_web/views/event_instance_view.ex
+++ b/apps/artemis_web/lib/artemis_web/views/event_instance_view.ex
@@ -55,6 +55,19 @@ defmodule ArtemisWeb.EventInstanceView do
     end
   end
 
+  @doc """
+  Render event instance form
+  """
+  def render_event_instance_form(conn, assigns \\ []) do
+    session = Map.delete(assigns, :conn)
+
+    Phoenix.LiveView.live_render(
+      conn,
+      ArtemisWeb.EventInstanceFormLive,
+      session: session
+    )
+  end
+
   # Helpers
 
   def render_show_link(_conn, nil), do: nil


### PR DESCRIPTION
When an event question is marked as `multiple: true`, the event instance form will now show `add` and `delete` answer actions.

Interactive form is implemented with Phoenix LiveView.